### PR TITLE
Upgrade font-carrier

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.2.0",
   "description": "Font convertor, TTF to SVG, for node.js",
   "main": "./src/index.js",
-  "scripts": {
-  },
+  "scripts": {},
   "bin": {
     "ttf2svg": "bin/ttf2svg.js"
   },
@@ -27,9 +26,7 @@
   },
   "homepage": "https://github.com/qdsang/ttf2svg",
   "dependencies": {
-    "font-carrier": "0.0.12"
+    "font-carrier": "0.3.0"
   },
-  "devDependencies": {
-
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
Some fonts have unsupported kern table versions (>= 1). This throws the following error:

```
Error: Unsupported kern table version.
    at Object.exports.argument (/ttf2svg/node_modules/opentype.js/src/check.js:9:15)
    at Object.parseKernTable [as parse] (ttf2svg/node_modules/opentype.js/src/tables/kern.js:15:11)
    at Object.parseBuffer [as parse] (ttf2svg/node_modules/opentype.js/src/opentype.js:182:38)
    at _parseTtfFont (ttf2svg/node_modules/font-carrier/lib/helper/engine.js:101:25)
    at Object.parse (ttf2svg/node_modules/font-carrier/lib/helper/engine.js:232:12)
    at Object.FontCarrier.transfer (ttf2svg/node_modules/font-carrier/lib/index.js:35:33)
    at ttf2svg (ttf2svg/src/index.js:6:30)
    at ttf2svg/bin/ttf2svg.js:32:22
```
This was an issue with `opentype.js`, and they have since fixed this issue. Newer versions of `font-carrier` use the fixed version of the package.

Upgrading to 0.3.0 is enough (I tested it)

```
node ./bin/ttf2svg.js ~/Downloads/Circular-Thin.ttf    
Only the first kern subtable is supported.
complete : Circular-Thin.svg!
```